### PR TITLE
Use a more concrete version for openbuildings/postmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
-        "openbuildings/postmark": "0.*"
+        "openbuildings/postmark": "~0.1.5"
     },
     "autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9fa495f5e76589b855e16eb40a482fbf",
+    "hash": "85d8b25424e061e9dbd8d9ec3df24eac",
     "packages": [
         {
             "name": "illuminate/support",
@@ -53,22 +53,55 @@
                 }
             ],
             "time": "2014-08-05 12:08:34"
+        },
+        {
+            "name": "openbuildings/postmark",
+            "version": "0.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenBuildings/postmark.git",
+                "reference": "6b45b80a2b4306f144188ebdd54f0b4deeadb383"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenBuildings/postmark/zipball/6b45b80a2b4306f144188ebdd54f0b4deeadb383",
+                "reference": "6b45b80a2b4306f144188ebdd54f0b4deeadb383",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "swiftmailer/swiftmailer": "~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Openbuildings\\Postmark\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Kerin",
+                    "email": "ivan@openbuildings.com",
+                    "role": "Author"
+                }
+            ],
+            "description": "Swiftmailer Transport Class for Postmark",
+            "time": "2014-09-19 10:49:14"
         }
     ],
-    "packages-dev": [
-
-    ],
-    "aliases": [
-
-    ],
+    "packages-dev": [],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
     "platform": {
         "php": ">=5.4.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }


### PR DESCRIPTION
Hey there, [OpenBuildings/postmark](https://github.com/openbuildings/postmark) contributor here.

I see you've required the Postmark Swiftmailer transport in `composer.json` with `0.*` version.

In general this is not good. `0.x.x` major version (as per the SemVer spec) says things could break at any time. We are also planning to do some breaking changes. So it would be good if you require something more concrete like `~0.1.5`. This tells Composer to load everything which is `0.1.*`, but at least `0.1.5`. So when we release `0.2.0` you would not get with `composer update` without changing `composer.json` first.

This may not be a problem for you, because you have a lock file. But when a new user installs your package, the lock file in your repository is not used. It will download the latest version like `0.2.0` or `0.3.0` and it would not work if there is a breaking change which does not work with your code.

I hope I explained it clearly. Hit me up with any questions!

And watch the OpenBuildings/Postmark repo: https://github.com/OpenBuildings/postmark/releases
Some new releases are coming up! 
